### PR TITLE
Visual updates: Title, Source, Clear Chant Displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,11 +113,11 @@
           <div id="chant-display" class="section">
             <h2> Chant Display </h2>
             <div id="chant-info">
-              <p> <i>Chant information will display here</i></p>
+              <p>Chant information will display here</p>
               <!-- Chant information goes here -->
             </div>
             <div id="chant-svg">
-              <p><i>Chant visual will appear here</i></p>
+              <p>Chant visual will appear here</p>
               <!-- Chant SVG goes here -->
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -16,188 +16,186 @@
 </head>
 
 <body>
-  <div>
-    <div id="navbar">
-      <button id="search-mode-btn">
-        Search
-      </button>
+  <div id="navbar">
+    <button id="search-mode-btn">
+      Search
+    </button>
 
-      <button id="cross-comparison-mode-btn">
-        Cross Comparison
-      </button>
+    <button id="cross-comparison-mode-btn">
+      Cross Comparison
+    </button>
 
-      <button>
-        <a href="https://github.com/ECHOES-from-the-Past/mei-analyser/wiki" rel="external" target="_blank">
-          Project Wiki
-        </a>
-      </button>
+    <button>
+      <a href="https://github.com/ECHOES-from-the-Past/mei-analyser/wiki" rel="external" target="_blank">
+        Project Wiki
+      </a>
+    </button>
 
-      <button id="refresh-database-btn">
-        Refresh Database
-      </button>
+    <button id="refresh-database-btn">
+      Refresh Database
+    </button>
 
-      <span style="color:red" id='refresh-database-warning' hidden>
-        Please refresh the database!
-      </span>
+    <span style="color:red" id='refresh-database-warning' hidden>
+      Please refresh the database!
+    </span>
 
-      <button id="devMode-btn">
-        Dev Mode
-      </button>
-    </div>
+    <button id="devMode-btn">
+      Dev Mode
+    </button>
+  </div>
 
-    <!-- Start of user interface -->
-    <div id="user-interface">
-      <!-- Start of search panel -->
-      <div id="search-panel" class="panel">
-        <div id="search-panel-grid">
-          <!-- Start of leftside search panel -->
-          <div id="search-panel-leftside">
-            <div class="section">
+  <!-- Start of user interface -->
+  <div id="user-interface">
+    <!-- Start of search panel -->
+    <div id="search-panel" class="panel">
+      <div id="search-panel-grid">
+        <!-- Start of leftside search panel -->
+        <div id="search-panel-leftside">
+          <div class="section">
 
-              <h1> Search Panel </h1>
-              <!-- <input id="pitch-radio" name="pattern-radio" type="radio" value="pitch" checked>
+            <h1> Search Panel </h1>
+            <!-- <input id="pitch-radio" name="pattern-radio" type="radio" value="pitch" checked>
               <label for="pitch-radio"> Pitch Pattern (pitch-based) </label>
               <br> -->
-              <!-- <input id="contour-radio" name="pattern-radio" type="radio" value="contour">
+            <!-- <input id="contour-radio" name="pattern-radio" type="radio" value="contour">
               <label for="contour-radio"> Contour (melodic intervals) </label>
               <br> -->
-              <!-- <label for="search-query"> Query: </label>
+            <!-- <label for="search-query"> Query: </label>
               <input id="search-query" placeholder="e.g.: 1 2 -1"> -->
-              <p> Search for chant with the following notation types: </p>
-              <input type="checkbox" id="aquitanian-checkbox" value="aquitanian-checkbox" checked>
-              <label for="aquitanian-checkbox"> Aquitanian </label>
-              <input type="checkbox" id="square-checkbox" value="square-checkbox">
-              <label for="square-checkbox"> Square </label>
-              <p> Search for chants that has ornamental figure(s): <br> (No selection will display all chants) </p>
-              <input type="checkbox" id="liquescent-checkbox" value="liquescent">
-              <label for="liquescent-checkbox"> Liquescent </label>
-              <input type="checkbox" id="quilisma-checkbox" value="quilisma">
-              <label for="quilisma-checkbox"> Quilisma </label>
-              <input type="checkbox" id="oriscus-checkbox" value="oriscus">
-              <label for="oriscus-checkbox"> Oriscus </label>
-              <br>
-              <br>
-              <button id="search-btn"> Search</button>
-              <!-- <button id="highlight-search-btn">Highlight on chant</button> -->
+            <p> Search for chant with the following notation types: </p>
+            <input type="checkbox" id="aquitanian-checkbox" value="aquitanian-checkbox" checked>
+            <label for="aquitanian-checkbox"> Aquitanian </label>
+            <input type="checkbox" id="square-checkbox" value="square-checkbox">
+            <label for="square-checkbox"> Square </label>
+            <p> Search for chants that has ornamental figure(s): <br> (No selection will display all chants) </p>
+            <input type="checkbox" id="liquescent-checkbox" value="liquescent">
+            <label for="liquescent-checkbox"> Liquescent </label>
+            <input type="checkbox" id="quilisma-checkbox" value="quilisma">
+            <label for="quilisma-checkbox"> Quilisma </label>
+            <input type="checkbox" id="oriscus-checkbox" value="oriscus">
+            <label for="oriscus-checkbox"> Oriscus </label>
+            <br>
+            <br>
+            <button id="search-btn"> Search</button>
+            <!-- <button id="highlight-search-btn">Highlight on chant</button> -->
 
-              <!-- Display search query when Dev Mode is enabled -->
-              <div class="devMode" hidden>
-                <!-- <p> Search choice: <span id="dev-searchChoice"></span> </p> -->
-                <!-- <p> Search query: <span id="dev-searchQuery"></span> </p> -->
-                <p> Ornamental shape: <span id="dev-ornamental-shapes"></span></p>
-              </div>
-
-            </div>
-
-            <div id="chant-list database" class="section">
-              <h2> Database </h2>
-              <button id="view-database-btn"> View database </button>
-              <div>
-                <ul id="database-list">
-                  <!-- Chant list goes here -->
-                </ul>
-              </div>
+            <!-- Display search query when Dev Mode is enabled -->
+            <div class="devMode" hidden>
+              <!-- <p> Search choice: <span id="dev-searchChoice"></span> </p> -->
+              <!-- <p> Search query: <span id="dev-searchQuery"></span> </p> -->
+              <p> Ornamental shape: <span id="dev-ornamental-shapes"></span></p>
             </div>
 
           </div>
-          <!-- End of leftside search panel -->
-          <!-- Start of rightside search panel -->
-          <div id="search-panel-rightside">
-            <div class="section">
-              <h1> Search Results </h1>
-              <div id="search-result">
-                <p> <i>Search results will display here</i></p>
 
-                <!-- Search results -->
-              </div>
-            </div>
-            <div id="chant-display" class="section">
-              <h2> Chant Display </h2>
-              <div id="chant-info">
-                <p> <i>Chant information will display here</i></p>
-                <!-- Chant information goes here -->
-              </div>
-              <div id="chant-svg">
-                <p><i>Chant visual will appear here</i></p>
-                <!-- Chant SVG goes here -->
-              </div>
-            </div>
-            <!-- End of rightside search panel -->
-          </div>
-          <!--  -->
-        </div>
-        <!-- End of search-panel-grid -->
-      </div>
-      <!-- end of search panel -->
-
-
-      <!-- Start of cross comparison panel -->
-      <div id="cross-comparison-panel" class="panel" hidden>
-        <h1> Cross comparison panel </h1>
-        <input type="radio" id="mismatch-analysis" name="analysis-mode" value="mismatch" checked>
-        <label for="mismatch-analysis"> Contour mismatches (blue) </label>
-        <br>
-        <input type="radio" id="gap-left" name="analysis-mode" value="gaps-left">
-        <label for="gap-left"> Contour gaps (red fillers on left chant) </label>
-        <br>
-        <input type="radio" id="gap-right" name="analysis-mode" value="gaps-right">
-        <label for="gap-right"> Contour gaps (red fillers on right chant) </label>
-        <br>
-        <input type="radio" id="gap-mismatch-left" name="analysis-mode" value="gaps-mismatch-left">
-        <label for="gap-mismatch-left"> Contour gaps and mismatches (red fillers on left chant) </label>
-        <br>
-        <input type="radio" id="gap-mismatch-right" name="analysis-mode" value="gaps-mismatch-right">
-        <label for="gap-mismatch-right"> Contour gaps and mismatches (red fillers on right chant) </label>
-        <br>
-        <br>
-        <button type="button" id="cross-comparison-btn">
-          Analyse
-        </button>
-        <br>
-        <div id="mei-grid">
-          <!-- File/Database selection part -->
-          <div id="mei-file-select">
+          <div id="chant-list database" class="section">
+            <h2> Database </h2>
+            <button id="view-database-btn"> View database </button>
             <div>
-              <label for="database-chant-left">Choose a chant from database:</label>
-              <select class="database-select" name="database-chant-left" id="database-chant-left">
-                <option value="placeholder">Select a chant for left slot</option>
-              </select>
+              <ul id="database-list">
+                <!-- Chant list goes here -->
+              </ul>
             </div>
-            <div>
-              <label for="database-chant-right">Choose a chant from database:</label>
-              <select class="database-select" name="database-chant-right" id="database-chant-right">
-                <option value="placeholder">Select a chant for the right slot</option>
-              </select>
-            </div>
-          </div>
-          <!-- File upload section -->
-          <div id="mei-file-select">
-            <p>or upload to left slot:
-              <span>
-                <input type='file' class="file-upload-box" id='file-input-left' />
-              </span>
-            </p>
-
-            <p>or upload to right slot:
-              <span>
-                <input type='file' class="file-upload-box" id='file-input-right' />
-              </span>
-            </p>
           </div>
 
-          <!-- Display of the chants -->
-          <div id="mei-display">
-            <div class="mei-file" id="mei-file-1">
-            </div>
-            <div class="mei-file" id="mei-file-2">
-            </div>
-          </div>
         </div>
+        <!-- End of leftside search panel -->
+        <!-- Start of rightside search panel -->
+        <div id="search-panel-rightside">
+          <div class="section">
+            <h1> Search Results </h1>
+            <div id="search-result">
+              <p> <i>Search results will display here</i></p>
+
+              <!-- Search results -->
+            </div>
+          </div>
+          <div id="chant-display" class="section">
+            <h2> Chant Display </h2>
+            <div id="chant-info">
+              <p> <i>Chant information will display here</i></p>
+              <!-- Chant information goes here -->
+            </div>
+            <div id="chant-svg">
+              <p><i>Chant visual will appear here</i></p>
+              <!-- Chant SVG goes here -->
+            </div>
+          </div>
+          <!-- End of rightside search panel -->
+        </div>
+        <!--  -->
       </div>
-      <!-- End of cross comparison panel -->
+      <!-- End of search-panel-grid -->
     </div>
-    <!-- End of user interface -->
+    <!-- end of search panel -->
+
+
+    <!-- Start of cross comparison panel -->
+    <div id="cross-comparison-panel" class="panel" hidden>
+      <h1> Cross comparison panel </h1>
+      <input type="radio" id="mismatch-analysis" name="analysis-mode" value="mismatch" checked>
+      <label for="mismatch-analysis"> Contour mismatches (blue) </label>
+      <br>
+      <input type="radio" id="gap-left" name="analysis-mode" value="gaps-left">
+      <label for="gap-left"> Contour gaps (red fillers on left chant) </label>
+      <br>
+      <input type="radio" id="gap-right" name="analysis-mode" value="gaps-right">
+      <label for="gap-right"> Contour gaps (red fillers on right chant) </label>
+      <br>
+      <input type="radio" id="gap-mismatch-left" name="analysis-mode" value="gaps-mismatch-left">
+      <label for="gap-mismatch-left"> Contour gaps and mismatches (red fillers on left chant) </label>
+      <br>
+      <input type="radio" id="gap-mismatch-right" name="analysis-mode" value="gaps-mismatch-right">
+      <label for="gap-mismatch-right"> Contour gaps and mismatches (red fillers on right chant) </label>
+      <br>
+      <br>
+      <button type="button" id="cross-comparison-btn">
+        Analyse
+      </button>
+      <br>
+      <div id="mei-grid">
+        <!-- File/Database selection part -->
+        <div id="mei-file-select">
+          <div>
+            <label for="database-chant-left">Choose a chant from database:</label>
+            <select class="database-select" name="database-chant-left" id="database-chant-left">
+              <option value="placeholder">Select a chant for left slot</option>
+            </select>
+          </div>
+          <div>
+            <label for="database-chant-right">Choose a chant from database:</label>
+            <select class="database-select" name="database-chant-right" id="database-chant-right">
+              <option value="placeholder">Select a chant for the right slot</option>
+            </select>
+          </div>
+        </div>
+        <!-- File upload section -->
+        <div id="mei-file-select">
+          <p>or upload to left slot:
+            <span>
+              <input type='file' class="file-upload-box" id='file-input-left' />
+            </span>
+          </p>
+
+          <p>or upload to right slot:
+            <span>
+              <input type='file' class="file-upload-box" id='file-input-right' />
+            </span>
+          </p>
+        </div>
+
+        <!-- Display of the chants -->
+        <div id="mei-display">
+          <div class="mei-file" id="mei-file-1">
+          </div>
+          <div class="mei-file" id="mei-file-2">
+          </div>
+        </div>
+      </div>
+    </div>
+    <!-- End of cross comparison panel -->
   </div>
+  <!-- End of user interface -->
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mei-analyser",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "devDependencies": {
     "vite": "^5.0.8"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,8 @@ import {
     devOrnamentalShapes,
     refreshDatabaseWarning,
     aquitanianCheckbox,
-    squareCheckbox
+    squareCheckbox,
+    chantDisplay
 } from './DOMelements.mjs';
 import {
     checkPersistanceExists,
@@ -153,6 +154,9 @@ viewDatabaseButton.addEventListener("click", () => {
 });
 
 searchButton.addEventListener("click", () => {
+    // Clear the display when performing a new search
+    chantDisplay.innerHTML = '';
+
     // Perform search and display the result
     let resultChantList = performSearch();
     showSearchResult(resultChantList);

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ import {
     refreshDatabaseWarning,
     aquitanianCheckbox,
     squareCheckbox,
-    chantDisplay
+    chantInfo,
+    chantSVG
 } from './DOMelements.mjs';
 import {
     checkPersistanceExists,
@@ -155,7 +156,8 @@ viewDatabaseButton.addEventListener("click", () => {
 
 searchButton.addEventListener("click", () => {
     // Clear the display when performing a new search
-    chantDisplay.innerHTML = '';
+    chantInfo.innerHTML = "<p><i>Chant information will display here</i></p>";
+    chantSVG.innerHTML = "<p><i> Click on the chant's file name to display </i></p>";
 
     // Perform search and display the result
     let resultChantList = performSearch();

--- a/src/search/search.js
+++ b/src/search/search.js
@@ -106,7 +106,7 @@ export function showSearchResult(resultChantList) {
   resultTable.id = "result-table"; // for CSS styling
 
   // Create the head row of the table: "File Name" -- "Notation Type" -- "Mode"
-  const tableHeadRows = ["File Name", "Notation", "Mode", "PEM Database URL"];
+  const tableHeadRows = ["Title", "Notation", "Mode", "Source", "PEM Database URL", "File Name"];
   let headRow = document.createElement('thead');
   for (let headRowElement of tableHeadRows) {
     let th = document.createElement('th');
@@ -134,8 +134,8 @@ export function showSearchResult(resultChantList) {
     // create a result row for each chant
     let resultRow = document.createElement('tr');
     // add the file name of the chant to row cell
-    let td1 = createTD(chant.fileName);
-    td1.addEventListener("click", () => {
+    let tdFileName = createTD(chant.fileName);
+    tdFileName.addEventListener("click", () => {
       // Set the box for the chant
       chantSVG.style.boxShadow = "0 0 2px 3px #888";
       chantSVG.innerHTML = drawSVGFromMEIContent(chant.meiContent);
@@ -143,10 +143,10 @@ export function showSearchResult(resultChantList) {
       printChantInformation(chant);
       chantDisplay.scrollIntoView({ behavior: "smooth" });
     });
-    td1.style.cursor = "pointer";
+    tdFileName.style.cursor = "pointer";
 
-    let td2 = createTD(chant.notationType);
-    let td3 = createTD(chant.mode);
+    let tdNotationType = createTD(chant.notationType);
+    let tdMode = createTD(chant.mode);
 
     /** @type {HTMLAnchorElement} */
     let td4link = document.createElement('a');
@@ -155,13 +155,20 @@ export function showSearchResult(resultChantList) {
     td4link.target = "_blank";
     td4link.rel = "noopener noreferrer";
 
-    let td4 = createTD();
-    td4.appendChild(td4link);
+    let tdPEMLink = createTD();
+    tdPEMLink.appendChild(td4link);
 
-    resultRow.appendChild(td1);
-    resultRow.appendChild(td2);
-    resultRow.appendChild(td3);
-    resultRow.appendChild(td4);
+    let tdSource = createTD(chant.source);
+    
+    let tdTitle = createTD(chant.title);
+
+    // In order: title, notation type, mode, source, PEM database URL, file name
+    resultRow.appendChild(tdTitle);
+    resultRow.appendChild(tdNotationType);
+    resultRow.appendChild(tdMode);
+    resultRow.appendChild(tdSource);
+    resultRow.appendChild(tdPEMLink);
+    resultRow.appendChild(tdFileName);
 
     tbody.appendChild(resultRow);
   }

--- a/src/search/search.js
+++ b/src/search/search.js
@@ -106,7 +106,7 @@ export function showSearchResult(resultChantList) {
   resultTable.id = "result-table"; // for CSS styling
 
   // Create the head row of the table: "File Name" -- "Notation Type" -- "Mode"
-  const tableHeadRows = ["Title", "Notation", "Mode", "Source", "PEM Database URL", "File Name"];
+  const tableHeadRows = ["Title", "Music Script", "Mode", "Source", "PEM Database URL", "File Name"];
   let headRow = document.createElement('thead');
   for (let headRowElement of tableHeadRows) {
     let th = document.createElement('th');

--- a/src/utility/components.js
+++ b/src/utility/components.js
@@ -146,6 +146,19 @@ export class NeumeComponentAQ extends NeumeComponent {
   }
 }
 
+/**
+ * @typedef {Object} Chant
+ * @property {string} filePath the path of the .mei file
+ * @property {string} fileName the name of the .mei file
+ * @property {string} meiContent the XML content of the .mei file as a string
+ * @property {XMLDocument} meiParsedContent the parsed XML content of the .mei file
+ * @property {string} notationType the notation type of the chant (either "aquitanian" or "square")
+ * @property {NeumeComponentAQ[] | NeumeComponentSQ[]} neumeComponents an array of NeumeComponent belongs to the chant
+ * @property {string | number} mode the mode of the chant and/or extra information about the mode
+ * @property {string} pemDatabaseUrl hyperlink address to the Portuguese Early Music database
+ * 
+ */
+
 export class Chant {
   /**
    * Constructing a Chant object from a .mei file content
@@ -180,6 +193,10 @@ export class Chant {
      * @description the URL of the file on the PEM (Portuguese Early Music) database
     */
     this.pemDatabaseUrl = this.obtainDatabaseUrl();
+
+    this.title = this.obtainTitle();
+    
+    this.source = this.obtainSource();
   }
 
   /**
@@ -415,6 +432,18 @@ export class Chant {
     const itemTargetTypeURL = fileManifestation.querySelector("item[targettype='url']");
     const url = itemTargetTypeURL.attributes.getNamedItem("target").value;
     return url;
+  }
+
+  obtainTitle() {
+    const fileDescription = this.meiParsedContent.querySelector('fileDesc');
+    const title = fileDescription.querySelector('title').innerHTML;
+    return title;
+  }
+
+  obtainSource() {
+    const fileManifestation = this.meiParsedContent.querySelector('manifestation');
+    const source = fileManifestation.querySelector('identifier').innerHTML;
+    return source;
   }
 
   getFilePath() {


### PR DESCRIPTION
- Resolves #18 
  - [x] Clear chant display when performing a new search
- Resolves #17 
  - [x] Displaying chant's **title** and **source**
  - [x] Change the heading of the Notation column to Music Script
  - [x] And move the File Name column to the last on the right

Currently, the result table is looking like this:

![image](https://github.com/ECHOES-from-the-Past/mei-analyser/assets/24505220/c4bcb601-c839-42c0-a49d-45207c987605)

The repeated URL on PEM Database link can be shorten to only the number and/or an icon perhaps. Displaying chant can also be its separate button instead of the click-able file name.

